### PR TITLE
Migrate to Neovim v0.12.0

### DIFF
--- a/lua/core/commands.lua
+++ b/lua/core/commands.lua
@@ -30,11 +30,15 @@ end, { range = true, desc = "Copy the file name of the current file to the clipb
 
 -- LSP制御コマンド
 vim.api.nvim_create_user_command("Nonts", function()
-	vim.lsp.stop_client(vim.lsp.get_clients({ name = "ts_ls" }))
+	for _, client in ipairs(vim.lsp.get_clients({ name = "ts_ls" })) do
+		client:stop()
+	end
 end, { desc = "Stop TypeScript LSP server" })
 
 vim.api.nvim_create_user_command("Nondeno", function()
-	vim.lsp.stop_client(vim.lsp.get_clients({ name = "denols" }))
+	for _, client in ipairs(vim.lsp.get_clients({ name = "denols" })) do
+		client:stop()
+	end
 end, { desc = "Stop Deno LSP server" })
 
 -- Copilot制御コマンド

--- a/lua/core/options.lua
+++ b/lua/core/options.lua
@@ -64,6 +64,8 @@ vim.opt.ambiwidth = "single"
 vim.opt.winblend = 0
 vim.opt.pumblend = 0
 
+vim.opt.pumborder = "rounded"
+
 -- GUIカラーを使用
 vim.opt.termguicolors = true
 vim.opt.background = "dark"

--- a/lua/keymaps/lsp.lua
+++ b/lua/keymaps/lsp.lua
@@ -45,11 +45,11 @@ vim.api.nvim_create_autocmd("LspAttach", {
 
 		-- diagnostic navigation
 		vim.keymap.set("n", "[d", function()
-			vim.diagnostic.goto_prev({ float = { border = "rounded" } })
+			vim.diagnostic.jump({ count = -1, float = { border = "rounded" } })
 		end, vim.tbl_extend("force", opts, { desc = "Previous diagnostic" }))
 
 		vim.keymap.set("n", "]d", function()
-			vim.diagnostic.goto_next({ float = { border = "rounded" } })
+			vim.diagnostic.jump({ count = 1, float = { border = "rounded" } })
 		end, vim.tbl_extend("force", opts, { desc = "Next diagnostic" }))
 
 		vim.keymap.set("n", "<leader>dl", vim.diagnostic.setloclist, vim.tbl_extend("force", opts, { desc = "Diagnostic list" }))

--- a/lua/lsp/init.lua
+++ b/lua/lsp/init.lua
@@ -71,7 +71,7 @@ vim.api.nvim_create_user_command("LspRestart", function(opts)
 	end
 
 	for _, client in ipairs(clients) do
-		vim.lsp.stop_client(client.id)
+		client:stop()
 	end
 
 	-- 停止後にバッファを再読み込みしてLSPを再起動
@@ -86,7 +86,7 @@ vim.api.nvim_create_user_command("LspStop", function(opts)
 	local name = opts.args ~= "" and opts.args or nil
 	local clients = vim.lsp.get_clients({ name = name })
 	for _, client in ipairs(clients) do
-		vim.lsp.stop_client(client.id)
+		client:stop()
 	end
 	vim.notify(string.format("Stopped %d client(s)", #clients))
 end, { nargs = "?", desc = "Stop LSP client(s)" })


### PR DESCRIPTION
## 📋 Summary
Migrate Neovim configuration to v0.12.0, replacing deprecated APIs with their modern equivalents.

## 🔧 Changes

### Deprecated API Migration
- **`vim.lsp.stop_client()` → `client:stop()`**: Replaced all 4 call sites with the new instance method API (deprecated since 0.11)
  - `lua/lsp/init.lua`: `LspRestart` and `LspStop` commands
  - `lua/core/commands.lua`: `Nonts` and `Nondeno` commands
- **`vim.diagnostic.goto_prev/goto_next` → `vim.diagnostic.jump()`**: Migrated diagnostic navigation keymaps `[d`/`]d` to the new unified API (deprecated since 0.10)

### New 0.12.0 Options
- **`pumborder = "rounded"`**: Enable popup menu border, consistent with existing float border settings

## 🗂️ Changed Files
- **LSP**: `lua/lsp/init.lua`, `lua/core/commands.lua`
- **Keymaps**: `lua/keymaps/lsp.lua`
- **Options**: `lua/core/options.lua`

## 🧪 Verification
- [x] `nvim --version` → v0.12.0 confirmed
- [x] Headless startup without errors
- [ ] `:checkhealth` — no deprecation warnings
- [ ] `:LspRestart` / `:LspStop` / `:Nonts` / `:Nondeno`
- [ ] `[d` / `]d` diagnostic jump with float border
- [ ] `K` hover window

## 📦 Breaking Changes
None — all API replacements are backward-compatible with 0.10+/0.11+.